### PR TITLE
API Externa vinculada, RapidAPI, que posee un wine search

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,4 @@
+# Copia estas dos lineas a un archivo con nombre ".env" y rellena tu clave, que se obtiene en la pagina de la API, busquenla como key, es alfanumerica extensa.
+
+RAPIDAPI_KEY=
+RAPIDAPI_HOST=wine-explorer-api-ratings-insights-and-search.p.rapidapi.com

--- a/.gitignore
+++ b/.gitignore
@@ -205,3 +205,6 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# secrets
+.env

--- a/ImpoVinos/external_views.py
+++ b/ImpoVinos/external_views.py
@@ -1,0 +1,59 @@
+# ImpoVinos/external_views.py
+import os
+import requests
+
+from rest_framework.views import APIView
+from rest_framework.response import Response
+from rest_framework import status
+
+
+RAPIDAPI_HOST = os.environ.get(
+    "RAPIDAPI_HOST",
+    "wine-explorer-api-ratings-insights-and-search.p.rapidapi.com",  # host por defecto de esta API
+)
+RAPIDAPI_KEY = os.environ.get("RAPIDAPI_KEY", "")
+
+BASE_URL = f"https://{RAPIDAPI_HOST}"
+SEARCH_PATH = "/search"  # del snippet: /search?wine_name=...
+
+class WineExplorerSearchView(APIView):
+    """
+    GET /api/v1/external/wine-explorer/search/?q=syrah
+    Traduce 'q' -> 'wine_name' para el proveedor.
+    Requiere RAPIDAPI_KEY (y opcionalmente RAPIDAPI_HOST) en variables de entorno.
+    """
+
+    def get(self, request):
+        if not RAPIDAPI_KEY:
+            return Response(
+                {"detail": "Falta RAPIDAPI_KEY en variables de entorno (.env)."},
+                status=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            )
+
+        q = (request.query_params.get("q") or request.query_params.get("wine_name") or "").strip()
+        if not q:
+            return Response({"detail": "Falta parámetro 'q'."}, status=status.HTTP_400_BAD_REQUEST)
+
+        headers = {
+            "X-RapidAPI-Key": RAPIDAPI_KEY,
+            "X-RapidAPI-Host": RAPIDAPI_HOST,
+            "Accept": "application/json",
+        }
+        params = {"wine_name": q}  # este endpoint usa 'wine_name'
+
+        try:
+            r = requests.get(BASE_URL + SEARCH_PATH, headers=headers, params=params, timeout=12)
+            r.raise_for_status()
+            # Intentar parsear JSON; si no, devolver texto
+            try:
+                data = r.json()
+            except ValueError:
+                data = {"raw": r.text}
+            return Response(data, status=r.status_code)
+        except requests.exceptions.HTTPError:
+            return Response(
+                {"detail": "Error HTTP del proveedor", "status": r.status_code, "body": r.text[:1000]},
+                status=r.status_code,
+            )
+        except requests.exceptions.RequestException as e:
+            return Response({"detail": f"Error de red externo: {e}"}, status=status.HTTP_502_BAD_GATEWAY)

--- a/ImpoVinos/urls.py
+++ b/ImpoVinos/urls.py
@@ -3,12 +3,14 @@ from . import views
 from django.contrib.auth import views as auth_views
 from rest_framework.routers import DefaultRouter
 from .views import VinoViewSet
+from .external_views import WineExplorerSearchView
 
 router = DefaultRouter()
 router.register(r'vinos', VinoViewSet, basename='vinos')
 
 urlpatterns = [
     path('v1/', include(router.urls)),
+    path('v1/external/wine-explorer/search/', WineExplorerSearchView.as_view(), name='wine-explorer-search'),
     # Para la landing page
     path("", views.index, name="index"),
 

--- a/LEEME.TXT
+++ b/LEEME.TXT
@@ -1,0 +1,16 @@
+Para asegurarnos de que corra la app sin problemas
+instalar con pip install:
+Django 
+djangorestframework
+oracledb
+requests
+python-dotenv
+
+
+Ademas, estamos usando BD local, en settings pueden encontrar los datos de usuario, encontrar
+
+Finalmente, deben crear su archivo .env con la base que tiene el env.example y rellenarlo con la key de la API. Esta key se obtiene
+creando una cuenta en su pagina, eligen el plan gratis que tiene limite de consultas. La key es personal, ojo con eso.
+Pueden crear la cuenta vinculando su cuenta GitHub y se hace mas rapido el proceso.
+
+Nuevamente, recuerden que la API tiene consultas limitadas, traten de no hacer tantos request innecesarios.

--- a/SEMANA8/settings.py
+++ b/SEMANA8/settings.py
@@ -9,6 +9,13 @@ https://docs.djangoproject.com/en/5.2/topics/settings/
 For the full list of settings and their values, see
 https://docs.djangoproject.com/en/5.2/ref/settings/
 """
+import os
+try:
+    from dotenv import load_dotenv
+    load_dotenv()
+except Exception:
+    # dotenv no instalado: no pasa nada, solo no cargará .env
+    pass
 
 from pathlib import Path
 


### PR DESCRIPTION
- Endpoint backend (DRF) que proxea la API de Wine Explorer:
  - GET /api/v1/external/wine-explorer/search/?q=<texto> (el vino que se queira buscar)
- Carga de variables de entorno con python-dotenv.
- .env.example para que creen su .env e ingresen la key que les otorga la API a su cuenta
- leeme.txt

***Configuración requerida
1) Copiar `.env.example` → `.env`
2) Completar:
   RAPIDAPI_KEY=<su_clave> // busquenla en la API, esta dentro del snippet
   RAPIDAPI_HOST=wine-explorer-api-ratings-insights-and-search.p.rapidapi.com
3) `python manage.py runserver`

***Cómo probar
- http://localhost:8000/api/v1/external/wine-explorer/search/?q=syrah
  - Respuesta 200 con JSON del proveedor.
Recuerden que son llamadas limitadas a la API.